### PR TITLE
updated spree core dependency to 3.7

### DIFF
--- a/spree_simple_weight_calculator.gemspec
+++ b/spree_simple_weight_calculator.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_simple_weight_calculator'
-  s.version     = '3.2.0'
+  s.version     = '3.7.0'
   s.summary     = 'A Spree shipping costs calculator based on total order weight'
   s.required_ruby_version = '>= 1.9.3'
 
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.2.0'
+  s.add_dependency 'spree_core', '~> 3.7.0'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
updated spree core to support version 3.7  and bumped up gem version number to match.